### PR TITLE
Fix null pointer exception.

### DIFF
--- a/src/no/runsafe/entitycontrol/pets/CompanionHandler.java
+++ b/src/no/runsafe/entitycontrol/pets/CompanionHandler.java
@@ -181,6 +181,9 @@ public class CompanionHandler
 	 */
 	public void removeSummonedPets(IPlayer player)
 	{
+		if (summonedPets.get(player.getUniqueId()) == null)
+			return;
+
 		for (SummonedPet pet : summonedPets.get(player.getUniqueId()))
 			pet.getPet().remove();
 		summonedPets.remove(player.getUniqueId());


### PR DESCRIPTION
This should fix an exception when a player logs out without any companions summoned.
This bug was only effecting server4 and not the live server, I have no idea why this bug isn't present on the live server.  This should fix it on server4 at least.